### PR TITLE
provide atom an Show instance

### DIFF
--- a/src/Erl/Atom.purs
+++ b/src/Erl/Atom.purs
@@ -15,3 +15,5 @@ foreign import eqImpl :: Atom -> Atom -> Boolean
 instance atomEq :: Eq Atom where
   eq = eqImpl
 
+instance atomShow :: Show Atom where
+  show atom = "atom(" <> toString atom <> ")"


### PR DESCRIPTION
I thing it would be useful for some people (would be to me) that Atom provides a `Show` instance.
I hesitated to provide also a `Ord` instance but I'm not sure it makes sense, Erlang provide a sound comparison of atoms, but it seems to be more a consequence of the fact that all terms are comparable, not a useful usage.